### PR TITLE
JENKINS-38342 - Including also the labels defined in Cloud templates to be shown in LabelDashboard.

### DIFF
--- a/src/main/java/jenkins/plugins/linkedjobs/actions/LabelDashboardAction.java
+++ b/src/main/java/jenkins/plugins/linkedjobs/actions/LabelDashboardAction.java
@@ -189,7 +189,10 @@ public class LabelDashboardAction implements RootAction {
         for (Node node : Jenkins.getInstance().getNodes()) {
             listNodeLabels(nodesSelfLabels, tmpResult, node);
         }
-        
+
+        //list all available labels defined by all clouds' templates.
+        listCloudTemplateLabels(tmpResult);
+
         ArrayList<LabelAtomData> result = new ArrayList<LabelAtomData>();
         result.addAll(tmpResult.values());
         // sort labels alphabetically by name
@@ -498,6 +501,19 @@ public class LabelDashboardAction implements RootAction {
                 result.put(label, new LabelAtomData(label));
             }
             result.get(label).add(node);
+        }
+    }
+
+    private void listCloudTemplateLabels(HashMap<LabelAtom, LabelAtomData> result) {
+        //Listing all available labels so that later the cloud template related lables can be picked from them
+        for (Label label : Jenkins.getInstance().getLabels()) {
+            if (label.getClouds().size() > 0) {
+                for (LabelAtom labelAtom : label.listAtoms()) {
+                    if (!result.containsKey(labelAtom)) {
+                        result.put(labelAtom, new LabelAtomData(labelAtom));
+                    }
+                }
+            }
         }
     }
 }

--- a/src/main/resources/jenkins/plugins/linkedjobs/actions/LabelLinkedJobsAction/index.jelly
+++ b/src/main/resources/jenkins/plugins/linkedjobs/actions/LabelLinkedJobsAction/index.jelly
@@ -35,26 +35,30 @@ THE SOFTWARE.
     <l:main-panel>
 
       <j:set var="groups" value="${it.jobsGroups}" />
+      <j:set var="clouds" value="${it.provisioningClouds}" />
+
+      <h2>Label "${it.label}" is
       <j:choose>
         <j:when test="${empty(groups)}">
-          <p>
-            <h2>Label "${it.label}" is not used by jobs</h2>
-          </p>
+          not used by jobs
         </j:when>
         <j:otherwise>
-          <h2>Label "${it.label}" is used by the following job(s)</h2>
-          <br/>
+          used by the following job(s)
+        </j:otherwise>
+      </j:choose>
+      </h2>
+      <br/>
 
-          <j:set var="clouds" value="${it.provisioningClouds}" />
-          <j:if test="${it.getSize(clouds) > 0}">
+      <j:if test="${it.getSize(clouds) > 0}">
           <div>
             Provisioning cloud<j:if test="${it.getSize(clouds) > 1}">s</j:if>:
             <j:forEach var="cloud" items="${clouds}" varStatus="loopStatus">
               ${cloud.displayName}<j:if test="${!loopStatus.last}">,&#160;</j:if>
             </j:forEach>
           </div><br/>
-          </j:if>
-          
+      </j:if>
+
+      <j:if test="${!empty(groups)}">
           <j:forEach var="group" items="${groups}">
             <h3>Job<j:if test="${group.hasMoreThanOneJob}">s</j:if> configured with <a href="${rootURL}/${group.labelURL}">${group.label}</a></h3>
  
@@ -111,8 +115,7 @@ THE SOFTWARE.
             
             <br/><br/>
           </j:forEach>
-        </j:otherwise>
-      </j:choose>
+      </j:if>
 
     </l:main-panel>
 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-38342
Prehistory: 
  My team sometimes faces the problem when the job should be attached to label which is linked to a cloud template. The "label expression" may be auto-filled in job configuration page, but it is not convenient when you don't know what labels are available. 

The purpose of this pull request is to show also the labels linked to Cloud Templates (in the Labels Dashboard), so that later when the user creates a job he knows what are the available labels and to which clouds they are connected.  
