### PR TITLE
Fix spotbugs-annotations RequireUpperBoundDeps enforcer rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,14 @@ THE SOFTWARE.
   
 
   <dependencies>
+    <!-- Fix RequireUpperBoundDeps enforcer rule -->
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>4.2.3</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <!--  JENKINS-27588, need to define dependency on this plugin to be able -->
       <!--  to use its classes detect its configuration in jobs -->


### PR DESCRIPTION
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

run `mvn clean package` on branch `master`, I got the following errors:
```
[WARNING] Rule 4: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for com.github.spotbugs:spotbugs-annotations:3.1.12 paths to dependency are:
+-org.jenkins-ci.plugins:label-linked-jobs:6.0.2-SNAPSHOT
  +-com.github.spotbugs:spotbugs-annotations:3.1.12 (managed) <-- com.github.spotbugs:spotbugs-annotations:4.2.3
]
```

Therefore, I override `spotbugs-annotations` version and keep scope & option to fix the issue.