### PR TITLE
[JENKINS-68372] fix api

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,12 @@ Jenkins. The command is `jcli plugin upload`.
 
 # API
 
-URL: `GET http://localhost:8080/labelsdashboard/labelsData`
+URL: `GET http://localhost:8080/labelsdashboard/api/json`
 
 Response:
 ```
 {
-  "status": "ok",
-  "data": [
+  "labels": [
     {
       "cloudsCount": 0,
       "description": "",
@@ -30,6 +29,20 @@ Response:
       "pluginActiveForLabel": false,
       "triggeredJobs": [],
       "triggeredJobsCount": 0
+    }
+  ],
+  "nodes" : [
+    {
+      "hasMoreThanOneJob": false,
+      "jobs": [],
+      "jobsCount": 0,
+      "jobsWithLabelDefaultValue": [],
+      "jobsWithLabelDefaultValueCount": 0,
+      "triggeredJobs": [],
+      "triggeredJobsCount": 0,
+      "labelURL": "label/master/",
+      "name": "Jenkins",
+      "nodeURL": "computer/(master)/"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -87,53 +87,6 @@ THE SOFTWARE.
       <version>1.5.0</version>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <!-- SECURITY-595 -->
-      <!-- https://www.jenkins.io/doc/developer/handling-requests/stapler-accessible-type/ -->
-      <groupId>io.jenkins.stapler</groupId>
-      <artifactId>jenkins-stapler-support</artifactId>
-      <version>1.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.kohsuke.stapler</groupId>
-      <artifactId>stapler</artifactId>
-      <version>1.256</version>
-    </dependency>
-    <dependency>
-      <groupId>org.kohsuke.stapler</groupId>
-      <artifactId>json-lib</artifactId>
-      <version>2.4-jenkins-2</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.6</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jvnet.localizer</groupId>
-      <artifactId>localizer</artifactId>
-      <version>1.24</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-fileupload</groupId>
-      <artifactId>commons-fileupload</artifactId>
-      <version>1.3.1-jenkins-2</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-      <version>3.2.2</version>
-    </dependency>
-    <dependency>
-      <groupId>com.jcraft</groupId>
-      <artifactId>jzlib</artifactId>
-      <version>1.1.3-kohsuke-1</version>
-    </dependency>
   </dependencies>
 
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all 

--- a/src/main/java/jenkins/plugins/linkedjobs/actions/LabelDashboardAction.java
+++ b/src/main/java/jenkins/plugins/linkedjobs/actions/LabelDashboardAction.java
@@ -166,15 +166,15 @@ public class LabelDashboardAction implements RootAction {
         
         // build a list of all the nodes self labels
         HashSet<LabelAtom> nodesSelfLabels = new HashSet<LabelAtom>();
-        nodesSelfLabels.add(Jenkins.getInstance().getSelfLabel());
-        for (Node node : Jenkins.getInstance().getNodes()) {
+        nodesSelfLabels.add(Jenkins.get().getSelfLabel());
+        for (Node node : Jenkins.get().getNodes()) {
             nodesSelfLabels.add(node.getSelfLabel());
         }
         
         // This loop is directly inspired from hudson.model.Label.getTiedJobs()
         // List all LabelAtom used by all jobs, except nodes self labels that are
         // processed in getNodesData()
-        for (AbstractProject<?, ?> job : Jenkins.getInstance().getAllItems(AbstractProject.class)) {
+        for (AbstractProject<?, ?> job : Jenkins.get().getAllItems(AbstractProject.class)) {
             if (!(job instanceof TopLevelItem)) {
                 continue;
             }
@@ -229,8 +229,8 @@ public class LabelDashboardAction implements RootAction {
         
         // list all LabelAtom defined by all nodes, including Jenkins master node,
         // but ignore nodes' self labels. See listNodeLabels()
-        listNodeLabels(nodesSelfLabels, tmpResult, Jenkins.getInstance());
-        for (Node node : Jenkins.getInstance().getNodes()) {
+        listNodeLabels(nodesSelfLabels, tmpResult, Jenkins.get());
+        for (Node node : Jenkins.get().getNodes()) {
             listNodeLabels(nodesSelfLabels, tmpResult, node);
         }
 
@@ -252,7 +252,7 @@ public class LabelDashboardAction implements RootAction {
      * @return true only if all nodes are set to Mode.EXCLUSIVE
      */
     public static boolean getOnlyExclusiveNodes() {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         if (!Node.Mode.EXCLUSIVE.equals(jenkins.getMode())) {
             return false;
         }
@@ -269,7 +269,7 @@ public class LabelDashboardAction implements RootAction {
     // this function returns all jobs that have no associated label(s)
     public List<AbstractProject<?, ?>> getJobsWithNoLabels() {
         ArrayList<AbstractProject<?, ?>> noLabelsJobs = new ArrayList<AbstractProject<?, ?>>();
-        for (AbstractProject<?, ?> job : Jenkins.getInstance().getAllItems(AbstractProject.class)) {
+        for (AbstractProject<?, ?> job : Jenkins.get().getAllItems(AbstractProject.class)) {
             if (!(job instanceof TopLevelItem)) {
                 // consider only TopLevelItem - not 100% sure why, though...
                 continue;
@@ -304,7 +304,7 @@ public class LabelDashboardAction implements RootAction {
             }
             return false;
         }
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         if (label.matches(jenkins)) {
             // this job can run on the master, skip it
             return false;
@@ -318,7 +318,7 @@ public class LabelDashboardAction implements RootAction {
         }
         
         // JENKINS-32445, also look for clouds that could support this label
-        for (Cloud c : Jenkins.getInstance().clouds) {
+        for (Cloud c : Jenkins.get().clouds) {
             if (c.canProvision(label)) {
                 return false;
             }
@@ -355,7 +355,7 @@ public class LabelDashboardAction implements RootAction {
     // because of labels (mis-)configuration
     public List<AbstractProject<?, ?>> getOrphanedJobs() {
         ArrayList<AbstractProject<?, ?>> orphanedJobs = new ArrayList<AbstractProject<?, ?>>();
-        for (AbstractProject<?, ?> job : Jenkins.getInstance().getAllItems(AbstractProject.class)) {
+        for (AbstractProject<?, ?> job : Jenkins.get().getAllItems(AbstractProject.class)) {
             if (!(job instanceof TopLevelItem)) {
                 // consider only TopLevelItem - not 100% sure why, though...
                 continue;
@@ -380,7 +380,7 @@ public class LabelDashboardAction implements RootAction {
      */
     private Node isSingleNode(Label label) {
         Node node = null;
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         if (label.matches(jenkins)) {
             node  = jenkins;
         }
@@ -413,7 +413,7 @@ public class LabelDashboardAction implements RootAction {
     public List<NodeData> getSingleNodeJobs() {
         HashMap<Node, NodeData> tmpResult = new HashMap<Node, NodeData>();
 
-        for (AbstractProject<?, ?> job : Jenkins.getInstance().getAllItems(AbstractProject.class)) {
+        for (AbstractProject<?, ?> job : Jenkins.get().getAllItems(AbstractProject.class)) {
             if (!(job instanceof TopLevelItem)) {
                 // consider only TopLevelItem - not 100% sure why, though...
                 continue;
@@ -481,15 +481,15 @@ public class LabelDashboardAction implements RootAction {
         HashMap<LabelAtom, NodeData> tmpResult = new HashMap<LabelAtom, NodeData>();
         
         // prefill the results with all nodes
-        tmpResult.put(Jenkins.getInstance().getSelfLabel(),
-                new NodeData(Jenkins.getInstance()));
-        for (Node node : Jenkins.getInstance().getNodes()) {
+        tmpResult.put(Jenkins.get().getSelfLabel(),
+                new NodeData(Jenkins.get()));
+        for (Node node : Jenkins.get().getNodes()) {
             tmpResult.put(node.getSelfLabel(), new NodeData(node));
         }
         
         // This loop is directly inspired from hudson.model.Label.getTiedJobs()
         // Find all jobs that are using directly some nodes' self labels
-        for (AbstractProject<?, ?> job : Jenkins.getInstance().getAllItems(AbstractProject.class)) {
+        for (AbstractProject<?, ?> job : Jenkins.get().getAllItems(AbstractProject.class)) {
             if (!(job instanceof TopLevelItem)) {
                 continue;
             }
@@ -552,7 +552,7 @@ public class LabelDashboardAction implements RootAction {
 
     private void listCloudTemplateLabels(HashMap<LabelAtom, LabelAtomData> result) {
         //Listing all available labels so that later the cloud template related lables can be picked from them
-        for (Label label : Jenkins.getInstance().getLabels()) {
+        for (Label label : Jenkins.get().getLabels()) {
             if (label.getClouds().size() > 0) {
                 for (LabelAtom labelAtom : label.listAtoms()) {
                     if (!result.containsKey(labelAtom)) {

--- a/src/main/java/jenkins/plugins/linkedjobs/model/AbstractJobsGroup.java
+++ b/src/main/java/jenkins/plugins/linkedjobs/model/AbstractJobsGroup.java
@@ -30,6 +30,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+@ExportedBean(defaultVisibility=2)
 public abstract class AbstractJobsGroup {
 
     // list of jobs functionally tied to this label/node
@@ -61,32 +65,39 @@ public abstract class AbstractJobsGroup {
     // functions used to render display in index.jelly
     //************************************************
 
+    @Exported
     public int getJobsCount() {
         return jobs.size();
     }
 
+    @Exported
     public int getTriggeredJobsCount() {
         return triggeredJobs.size();
     }
     
     // return the number of jobs that uses this labelAtom or node's labelAtom
     // as (part of) their default value for a Label parameter
+    @Exported
     public int getJobsWithLabelDefaultValueCount() {
         return jobsWithLabelDefaultValue.size();
     }
     
+    @Exported
     public List<AbstractProject<?, ?>> getJobs() {
         return jobs;
     }
     
+    @Exported
     public List<TriggeredJob> getTriggeredJobs() {
         return triggeredJobs;
     }
     
+    @Exported
     public List<AbstractProject<?, ?>> getJobsWithLabelDefaultValue() {
         return jobsWithLabelDefaultValue;
     }
     
+    @Exported
     public boolean getHasMoreThanOneJob() {
         return (jobs.size() + triggeredJobs.size() + jobsWithLabelDefaultValue.size()) > 1;
     }

--- a/src/main/java/jenkins/plugins/linkedjobs/model/LabelAtomData.java
+++ b/src/main/java/jenkins/plugins/linkedjobs/model/LabelAtomData.java
@@ -26,6 +26,9 @@ package jenkins.plugins.linkedjobs.model;
 
 import java.util.ArrayList;
 
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
 import jenkins.model.Jenkins;
 import jenkins.plugins.linkedjobs.actions.LabelLinkedJobsAction;
 import hudson.model.Node;
@@ -53,6 +56,7 @@ public class LabelAtomData extends AbstractJobsGroup implements Comparable<Label
     // functions used to render display in index.jelly
     //************************************************
     
+    @Exported
     public String getDescription() {
         // configurable description for LabelAtom was implemented in Jenkins core v1.580
         if (Jenkins.getVersion() != null && !Jenkins.getVersion().isOlderThan(new VersionNumber("1.580"))) {
@@ -63,20 +67,24 @@ public class LabelAtomData extends AbstractJobsGroup implements Comparable<Label
         }
     }
     
+    @Exported
     public String getLabel() {
         return labelAtom.getDisplayName();
     }
     
+    @Exported
     public String getLabelURL() {
         return labelAtom.getUrl();
     }
     
+    @Exported
     public int getNodesCount() {
         return nodes.size();
     }
     
     // JENKINS-32445
     // return the number of clouds that can provision this atomic label
+    @Exported
     public int getCloudsCount() {
         int result = 0;
         for (Cloud c : Jenkins.getInstance().clouds) {
@@ -87,6 +95,7 @@ public class LabelAtomData extends AbstractJobsGroup implements Comparable<Label
         return result;
     }
     
+    @Exported
     public boolean getPluginActiveForLabel() {
         for (hudson.model.Action a : labelAtom.getActions()) {
             if (a instanceof LabelLinkedJobsAction) {

--- a/src/main/java/jenkins/plugins/linkedjobs/model/LabelAtomData.java
+++ b/src/main/java/jenkins/plugins/linkedjobs/model/LabelAtomData.java
@@ -27,14 +27,12 @@ package jenkins.plugins.linkedjobs.model;
 import java.util.ArrayList;
 
 import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.export.ExportedBean;
 
 import jenkins.model.Jenkins;
 import jenkins.plugins.linkedjobs.actions.LabelLinkedJobsAction;
 import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
 import hudson.slaves.Cloud;
-import hudson.util.VersionNumber;
 
 public class LabelAtomData extends AbstractJobsGroup implements Comparable<LabelAtomData> {
 
@@ -87,7 +85,7 @@ public class LabelAtomData extends AbstractJobsGroup implements Comparable<Label
     @Exported
     public int getCloudsCount() {
         int result = 0;
-        for (Cloud c : Jenkins.getInstance().clouds) {
+        for (Cloud c : Jenkins.get().clouds) {
             if (c.canProvision(labelAtom)) {
                 result++;
             }

--- a/src/main/java/jenkins/plugins/linkedjobs/model/LabelAtomData.java
+++ b/src/main/java/jenkins/plugins/linkedjobs/model/LabelAtomData.java
@@ -59,7 +59,7 @@ public class LabelAtomData extends AbstractJobsGroup implements Comparable<Label
     @Exported
     public String getDescription() {
         // configurable description for LabelAtom was implemented in Jenkins core v1.580
-        if (Jenkins.getVersion() != null && !Jenkins.getVersion().isOlderThan(new VersionNumber("1.580"))) {
+        if (Jenkins.getVersion() != null) {
             return labelAtom.getDescription() != null && labelAtom.getDescription().trim().length() > 0 ? labelAtom.getDescription() : null;
         }
         else {

--- a/src/main/java/jenkins/plugins/linkedjobs/model/NodeData.java
+++ b/src/main/java/jenkins/plugins/linkedjobs/model/NodeData.java
@@ -28,6 +28,7 @@ import jenkins.model.Jenkins;
 
 import org.kohsuke.stapler.export.Exported;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Node;
 
 public class NodeData extends AbstractJobsGroup implements Comparable<NodeData> {
@@ -54,6 +55,7 @@ public class NodeData extends AbstractJobsGroup implements Comparable<NodeData> 
     }
     
     @Exported
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",justification = "controller has always a computer")
     public String getNodeURL() {
         return Jenkins.get().getComputer(node.getNodeName()).getUrl();
     }

--- a/src/main/java/jenkins/plugins/linkedjobs/model/NodeData.java
+++ b/src/main/java/jenkins/plugins/linkedjobs/model/NodeData.java
@@ -28,7 +28,7 @@ import jenkins.model.Jenkins;
 
 import org.kohsuke.stapler.export.Exported;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.model.Computer;
 import hudson.model.Node;
 
 public class NodeData extends AbstractJobsGroup implements Comparable<NodeData> {
@@ -55,9 +55,12 @@ public class NodeData extends AbstractJobsGroup implements Comparable<NodeData> 
     }
     
     @Exported
-    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",justification = "controller has always a computer")
     public String getNodeURL() {
-        return Jenkins.get().getComputer(node.getNodeName()).getUrl();
+        Computer c = Jenkins.get().getComputer(node.getNodeName());
+        if (c != null) {
+            return c.getUrl();
+        }
+        return null;
     }
 
     /************************************

--- a/src/main/java/jenkins/plugins/linkedjobs/model/NodeData.java
+++ b/src/main/java/jenkins/plugins/linkedjobs/model/NodeData.java
@@ -25,6 +25,9 @@
 package jenkins.plugins.linkedjobs.model;
 
 import jenkins.model.Jenkins;
+
+import org.kohsuke.stapler.export.Exported;
+
 import hudson.model.Node;
 
 public class NodeData extends AbstractJobsGroup implements Comparable<NodeData> {
@@ -40,16 +43,19 @@ public class NodeData extends AbstractJobsGroup implements Comparable<NodeData> 
     // functions used to render display in index.jelly
     //************************************************
     
+    @Exported
     public String getName() {
         return node.getDisplayName();
     }
     
+    @Exported
     public String getLabelURL() {
         return node.getSelfLabel().getUrl();
     }
     
+    @Exported
     public String getNodeURL() {
-        return Jenkins.getInstance().getComputer(node.getNodeName()).getUrl();
+        return Jenkins.get().getComputer(node.getNodeName()).getUrl();
     }
 
     /************************************


### PR DESCRIPTION
[JENKINS-68372](https://issues.jenkins.io/browse/JENKINS-68372)
Due to cycles in AbstractProject, the api `/labelsdashboard/labelsData` isn't working.
Replace it with the Jenkins getApi approach, that allows to return json
or xml

This change also exposes the nodes as done in PR #16 

Also a lot of unnecessary imports are remove that blow up the resulting hpi.


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
